### PR TITLE
Fix training.inc corruption of edi on print_hex call

### DIFF
--- a/include/training.inc
+++ b/include/training.inc
@@ -14,9 +14,8 @@ read_hex:
     ; Keep some room for locals:
     sub     esp,16+4
 
-    push    ebx
     push    ecx
-    push    edx
+    push    edi
     
     lea     edi,[ebp + .read_hex_buffer]
     mov     ecx,.MAX_BYTES_TO_READ
@@ -37,9 +36,8 @@ read_hex:
     add     esp,4*3
 
     ; Result is inside eax.
-    pop     edx
+    pop     edi
     pop     ecx
-    pop     ebx
 
     add     esp,16+4
     pop     ebp


### PR DESCRIPTION
I noticed when attempting to do one of the exercises that my edi register was being overwritten by a constant value.  My code was clearly doing the right thing, and substituting ebx, instead worked just fine.

Guessing the culprit might be in 'read_hex' I took a look at training.inc and found the problem.  It looks like edx should have been edi (similar enough it probably got missed) and that ebx may have been used at some point, but is no longer.

Interestingly, read_hex seems to be one of the only 'methods' that doesn't just pushad/popad.  This, however, seemed like the minimal change.
