### PR TITLE
Removal of three redundant mov edx, 0 commands before running corresp…

### DIFF
--- a/4_basic_assembly/0_branching/4_structured_branching/answers/2_write_code/2.asm
+++ b/4_basic_assembly/0_branching/4_structured_branching/answers/2_write_code/2.asm
@@ -30,19 +30,16 @@ start:
 	mov		esi, 0		; used to add a^2 and b^2
 
 calculate:
-	mov		edx, 0
 	mov		eax, 0
 	mov   al, ch
 	mul   eax       ; a^2
 	mov		esi, eax	; store a^2 in esi
 
-	mov		edx, 0
 	mov		eax, 0
 	mov		al, bl
 	mul   eax       ; b^2
 	add		esi, eax	; a^2 + b^2
 
-	mov		edx, 0
 	mov		eax, 0
 	mov		al, bh
 	mul 	eax			; c^2 in eax


### PR DESCRIPTION
…onding mul commands

As per our email correspondence, I removed the redundant setting of the edx register to 0 on three lines. This is for the file: **asm_prog_ex\4_basic_assembly\0_branching\4_structured_branching\answers\2_write_code\2.asm**.

I redirected the output before and after the modifications using an input value of 7F on both runs. Comparing the two outputs yielded the following result when compared:
![image](https://user-images.githubusercontent.com/44066444/87714557-eb3f8400-c779-11ea-8499-3928467febd9.png)

Outputs are a match!
