### PR TITLE
Simplification of useless instruction

### DIFF
--- a/4_basic_assembly/4_strings/4_ex/2_read_code/4_inner_mess.asm
+++ b/4_basic_assembly/4_strings/4_ex/2_read_code/4_inner_mess.asm
@@ -84,8 +84,7 @@ string_not_empty:
     mov     ecx,dword [slen]
     mov     al,'['
     repnz scasb
-
-    dec     edi
+    
     mov     dword [first_b],edi
 
     ; Find the last bracket:
@@ -113,7 +112,6 @@ string_not_empty:
 
     ; Start printing right after the first bracket:
     mov     esi,dword [first_b]
-    inc     esi
     
     call    print_str
 


### PR DESCRIPTION
we are first decreasing edi to point at the address of the left bracket and at the end we are increasing edi to point at the byte after the bracket, we can just remove both to produce the same result.