### PR TITLE
Updated nibble to byte

### DIFF
--- a/4_basic_assembly/1_signed_operations/answers/1_read_code/4_two_pack.asm
+++ b/4_basic_assembly/1_signed_operations/answers/1_read_code/4_two_pack.asm
@@ -33,8 +33,8 @@
 ;	ANSWER:
 ;
 ;		It takes 1 input of max ffffh. If it is below or equal to ffffh, the first
-;		nibble is sign extended (so numbers below 0 are kept intact) and the
-;		second nibble is zero extended (treated as a unsigned number). Those numbers
+;		byte is sign extended (so numbers below 0 are kept intact) and the
+;		second byte is zero extended (treated as a unsigned number). Those numbers
 ;		are multiplied and the result is printed. If the number is above ffffh, the
 ;		number is directly printed back.
 ;


### PR DESCRIPTION
From my understanding, a nibble is only 4-bits and represented by 1 hexadecimal character, while a byte is 8-bits and represented by 2 hexadecimal characters. Based on my understanding of this code, it takes a 2-byte number and operates on the least significant and most significant bytes of the 2-byte number from the user. Because of this, nibble should probably be replaced by byte to convey the correct size of the values being operated on.